### PR TITLE
Creating a base exception type

### DIFF
--- a/zephyrus_sc2_parser/exceptions.py
+++ b/zephyrus_sc2_parser/exceptions.py
@@ -1,4 +1,9 @@
-class MissingMmrError(Exception):
+class Sc2ParserException(Exception):
+    """Base class for SC2 Parser exceptions."""
+    pass
+
+
+class MissingMmrError(Sc2ParserException):
     """
     Occurs when a player's MMR is missing and
     a replay is not being parsed in local mode
@@ -6,7 +11,7 @@ class MissingMmrError(Exception):
     pass
 
 
-class ReplayDecodeError(Exception):
+class ReplayDecodeError(Sc2ParserException):
     """
     Occurs when a replay is unable to be decoded
     using s2protocol
@@ -19,14 +24,14 @@ class ReplayDecodeError(Exception):
     pass
 
 
-class PlayerCountError(Exception):
+class PlayerCountError(Sc2ParserException):
     """
     Occurs when there are not exactly 2 players in the replay
     """
     pass
 
 
-class GameLengthNotFoundError(Exception):
+class GameLengthNotFoundError(Sc2ParserException):
     """
     Occurs when a game ends without PlayerLeave events. I have no idea why this happens
     """


### PR DESCRIPTION
Typically Python packages have a single, base exception type, so that the user can easily catch all possible exceptions from the library. This PR adds a base type, and sets the other exceptions to inherit from the base.

(As an example, see https://github.com/psf/requests/blob/master/requests/exceptions.py )