### PR TITLE
Added fallback to the latest protocol if specific build can't be found

### DIFF
--- a/zephyrus_sc2_parser/parser.py
+++ b/zephyrus_sc2_parser/parser.py
@@ -156,7 +156,11 @@ def _setup(filename, local, _test):
         try:
             header = versions.latest().decode_replay_header(header_content)
             base_build = header['m_version']['m_baseBuild']
-            protocol = versions.build(base_build)
+            try:
+                protocol = versions.build(base_build)
+            except ImportError:
+                # if the build can't be found, we fallback to the latest version
+                protocol = versions.latest()
 
             # accessing neccessary parts of file for data
             contents = archive.read_file('replay.tracker.events')


### PR DESCRIPTION
Hi, I used this parser recently a lot and there's an issue, usually with newer game builds, where the specific protocol can't be found but giving it a shot with the latest available still gets the job done in majority of cases. It helped me personally a lot so I figured that it might be worth to include it in the master repo as well. 

The worst that can happen is just that the replay wouldn't be possible to parse anyways due to some random protocol-related error, but there's much to gain as noticed in my personal experimentation. 